### PR TITLE
Upgrade guava from 28.2-jre to 29.0-jre

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -14,7 +14,7 @@ plugin.org.danilopianini.publish-on-central=0.2.0
 
 plugin.org.jlleitschuh.gradle.ktlint=9.0.0
 
-version.com.google.guava..guava=28.2-jre
+version.com.google.guava..guava=29.0-jre
 
 version.commons-io..commons-io=2.6
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.