### PR TITLE
Upgrade commons-io from 2.6 to 2.7

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -16,6 +16,6 @@ plugin.org.jlleitschuh.gradle.ktlint=9.0.0
 
 version.com.google.guava..guava=29.0-jre
 
-version.commons-io..commons-io=2.6
+version.commons-io..commons-io=2.7
 
 version.junit.junit=4.13


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.