### PR TITLE
Upgrade git-sensitive-semantic-versioning from 0.1.0 to 0.2.1

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -7,7 +7,7 @@
 
 plugin.com.github.spotbugs=4.0.6
 
-plugin.org.danilopianini.git-sensitive-semantic-versioning=0.1.0
+plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.1
 
 plugin.org.danilopianini.javadoc.io-linker=0.1.4
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.