### PR TITLE
Upgrade commons-io from 2.7 to 2.8.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -17,6 +17,6 @@ plugin.org.jlleitschuh.gradle.ktlint=9.4.0
 
 version.com.google.guava..guava=29.0-jre
 
-version.commons-io..commons-io=2.7
+version.commons-io..commons-io=2.8.0
 
 version.junit.junit=4.13


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.