### PR TITLE
Upgrade guava from 30.1-android to 30.1-jre

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -15,7 +15,7 @@ plugin.org.danilopianini.publish-on-central=0.4.0
 
 plugin.org.jlleitschuh.gradle.ktlint=9.4.1
 
-version.com.google.guava..guava=30.1-android
+version.com.google.guava..guava=30.1-jre
 
 version.commons-io..commons-io=2.8.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.