### PR TITLE
Upgrade junit from 4.13.1 to 4.13.2

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -19,4 +19,4 @@ version.com.google.guava..guava=30.1-jre
 
 version.commons-io..commons-io=2.8.0
 
-version.junit.junit=4.13.1
+version.junit.junit=4.13.2


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.