### PR TITLE
Upgrade commons-io from 2.10.0 to 2.11.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -17,6 +17,6 @@ plugin.org.jlleitschuh.gradle.ktlint=10.1.0
 
 version.com.google.guava..guava=30.1.1-jre
 
-version.commons-io..commons-io=2.10.0
+version.commons-io..commons-io=2.11.0
 
 version.junit.junit=4.13.2


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.